### PR TITLE
+ Right congruence can be proved

### DIFF
--- a/src/Algebra/Graph.agda
+++ b/src/Algebra/Graph.agda
@@ -21,6 +21,7 @@ data _≡_ {A} : (x y : Graph A) -> Set where
 
     -- Congruence
     +left-congruence  : ∀ {x y z : Graph A} -> x ≡ y -> x + z ≡ y + z
+    -- +right-congruence holds as a theorem, please see below
     *left-congruence  : ∀ {x y z : Graph A} -> x ≡ y -> x * z ≡ y * z
     *right-congruence : ∀ {x y z : Graph A} -> x ≡ y -> z * x ≡ z * y
 
@@ -37,6 +38,9 @@ data _≡_ {A} : (x y : Graph A) -> Set where
     left-distributivity  : ∀ {x y z : Graph A} -> x * (y + z) ≡ x * y + x * z
     right-distributivity : ∀ {x y z : Graph A} -> (x + y) * z ≡ x * z + y * z
     decomposition        : ∀ {x y z : Graph A} -> x * y * z   ≡ x * y + x * z + y * z
+
++right-congruence : ∀ {A} {x y z : Graph A} -> x ≡ y -> z + x ≡ z + y
++right-congruence {_} {x} {y} {z} eq = transitivity +commutativity (transitivity (+left-congruence eq) +commutativity)
 
 -- Subgraph relation
 _⊆_ : ∀ {A} -> Graph A -> Graph A -> Set

--- a/src/Algebra/Graph.agda
+++ b/src/Algebra/Graph.agda
@@ -21,7 +21,6 @@ data _≡_ {A} : (x y : Graph A) -> Set where
 
     -- Congruence
     +left-congruence  : ∀ {x y z : Graph A} -> x ≡ y -> x + z ≡ y + z
-    +right-congruence : ∀ {x y z : Graph A} -> x ≡ y -> z + x ≡ z + y
     *left-congruence  : ∀ {x y z : Graph A} -> x ≡ y -> x * z ≡ y * z
     *right-congruence : ∀ {x y z : Graph A} -> x ≡ y -> z * x ≡ z * y
 

--- a/src/Algebra/Graph/Reasoning.agda
+++ b/src/Algebra/Graph/Reasoning.agda
@@ -35,15 +35,6 @@ L : ∀ {op : BinaryOperator} -> ∀ {A} {x y z : Graph A} -> x ≡ y -> apply o
 L {+op} {x} {y} {z} eq = +left-congruence {x} {y} {z} eq
 L {*op} {x} {y} {z} eq = *left-congruence {x} {y} {z} eq
 
-+right-congruence : ∀ {A} {x y z : Graph A} -> x ≡ y -> z + x ≡ z + y
-+right-congruence {_} {x} {y} {z} eq =
-  begin
-    z + x ≡⟨ +commutativity ⟩
-    x + z ≡⟨ +left-congruence eq ⟩
-    y + z ≡⟨ +commutativity  ⟩
-    z + y
-  ∎
-
 R : ∀ {op : BinaryOperator} -> ∀ {A} {x y z : Graph A} -> x ≡ y -> apply op z x ≡ apply op z y
 R {+op} {x} {y} {z} eq = +right-congruence {x} {y} {z} eq
 R {*op} {x} {y} {z} eq = *right-congruence {x} {y} {z} eq

--- a/src/Algebra/Graph/Reasoning.agda
+++ b/src/Algebra/Graph/Reasoning.agda
@@ -35,6 +35,15 @@ L : ∀ {op : BinaryOperator} -> ∀ {A} {x y z : Graph A} -> x ≡ y -> apply o
 L {+op} {x} {y} {z} eq = +left-congruence {x} {y} {z} eq
 L {*op} {x} {y} {z} eq = *left-congruence {x} {y} {z} eq
 
++right-congruence : ∀ {A} {x y z : Graph A} -> x ≡ y -> z + x ≡ z + y
++right-congruence {_} {x} {y} {z} eq =
+  begin
+    z + x ≡⟨ +commutativity ⟩
+    x + z ≡⟨ +left-congruence eq ⟩
+    y + z ≡⟨ +commutativity  ⟩
+    z + y
+  ∎
+
 R : ∀ {op : BinaryOperator} -> ∀ {A} {x y z : Graph A} -> x ≡ y -> apply op z x ≡ apply op z y
 R {+op} {x} {y} {z} eq = +right-congruence {x} {y} {z} eq
 R {*op} {x} {y} {z} eq = *right-congruence {x} {y} {z} eq


### PR DESCRIPTION
If I have understood everything correctly (nothing is less sure, I never read Agda code before this afternoon): `+right-congruence`  is considered as an axiom, but one can prove `+right-congruence` from `+left-congruence` using commutativity.

I also tried to prove the equivalent for `*right-congruence` , but my agda's skills are not good at all ^^. The idea is to use that `transpose` is an injection.
So to prove `*right-congruence`, I can prove `∀ {x y z : Graph A} -> x ≡ y -> transpose (z * x) ≡ transpose (z * y)`
and in fact that `transpose (x * y) = transpose y * transpose x`
and here I can use `*left-congruence` to obtain what I want.
