### PR TITLE
make verify.sh actually verify

### DIFF
--- a/verify.sh
+++ b/verify.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
 rm -rf index.agda;
 echo "module index where" >> index.agda;
 for i in $( find src -name "*.agda" | sed 's/src\/\(.*\)\.agda/\1/' | sed 's/\//\./g' | sort ); do


### PR DESCRIPTION
Without `set -e` bash defaults to proceeding despite some failures and returns the exit code of the last command (which happens to be `rm` instead of `agda`).

"-uo pipefail" are not immediately relevant. They make bash stricter in other ways.

While we're at it, add a shebang so that the file is actually executable by linux (and not just by shell).